### PR TITLE
Use marked instead of markdown-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![npm](http://img.shields.io/npm/v/preact-markdown.svg)](https://www.npmjs.com/package/preact-markdown)
 
-[Markdown] in [Preact Markup]
+Markdown in [Preact Markup] using [Marked]
 
-[Markdown]: https://github.com/evilstreak/markdown-js
+[Marked]: https://github.com/chjj/marked
 [Preact Markup]: https://github.com/developit/preact-markup
 [hyperscript]: https://github.com/queckezz/preact-hyperscript
 

--- a/index.js
+++ b/index.js
@@ -1,18 +1,18 @@
 var h = require('preact').h
 var Markup = require('preact-markup')
-var toHTML = require('markdown').markdown.toHTML
+var marked = require('marked')
 
 module.exports = Markdown
 
 function Markdown(props) {
   if (typeof props === 'string') {
     return h(Markup, {
-      markup: toHTML(props),
+      markup: marked(props),
       trim: false,
     })
   } else if (props && props.markdown) {
     return h(Markup, Object.assign({
-      markup: toHTML(props.markdown),
+      markup: marked(props.markdown),
       trim: false,
     }, props))
   } else {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "files": [],
   "repository": "preact-markdown",
   "dependencies": {
-    "markdown": "^0.5.0",
+    "marked": "^0.3.6",
     "preact-markup": "^1.6.0"
   },
   "peer-dependencies": {


### PR DESCRIPTION
Size difference: 

* Clean install (with respective node_modules):

  * markdown-js: 1.82mB
  * marked: 70kB

* effective: (uglified/bablified gzipped)

  * markdown-js: 6.24kB (+2.6kB for util.js?) 
  * marked: 5.16kB

[comparison gist](https://gist.github.com/laggingreflex/56499f17476c3945fbcc480f4a6e4cfb)

Differences talked about in respective repo's issues
https://github.com/evilstreak/markdown-js/issues/90
https://github.com/chjj/marked/issues/156

Fixes #1