### PR TITLE
fix empty string error

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function Markdown(props, opts) {
       trim: false,
       type: 'html',
     }, opts.markupOpts))
-  } else if (props && props.markdown) {
+  } else if (props && typeof props.markdown === 'string') {
     var markupOpts = props.markupOpts || opts.markupOpts || {}
     var markdownOpts = props.markdownOpts || opts.markdownOpts || {}
     return h(Markup, Object.assign({


### PR DESCRIPTION
While props.markdown is empty string, it shows the error below
> Uncaught Error: Invalid arguments. Markdown requires either a `<String>` or object: `{markdown: <String>}`

I change the checking statement for props.markdown for correcting empty string input.
Please check it. Thank you :)
