### PR TITLE
Update marked to 0.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": "preact-markdown",
   "dependencies": {
-    "marked": "^0.3.6",
+    "marked": "^0.6.2",
     "preact-markup": "^1.6.0"
   },
   "peer-dependencies": {


### PR DESCRIPTION
`npm audit` reports "Regular Expression Denial of Service" vulnerability in earlier versions of `marked`.